### PR TITLE
Create new start to skip grinding

### DIFF
--- a/data/starts/-missions and events.txt
+++ b/data/starts/-missions and events.txt
@@ -5,26 +5,6 @@ mission "set main plot global"
 		has "main plot completed"
 	on offer
 		set "global: main plot completed"
-start "Revealed Map"
-	name "I Hate Exploring"
-	description `You grew up on New Boston, an uninteresting world in the Dirt Belt. You've dreamed of owning a starship ever since your first visit to the spaceport at the age of fifteen. After many long years of working at a textile mill, you've finally saved enough credits to apply for a pilot's license from the Republic.`
-	description `	This start is identical to the default start, however all systems and wormholes are revealed immediately`
-	thumbnail "scene/lobby"
-	date 16 11 3013
-	system "Rutilicus"
-	planet "New Boston"
-	conversation "default intro"
-	account
-		credits 480000
-		score 400
-		mortgage Mortgage
-			principal 480000
-			interest 0.004
-			term 365
-	set "license: Pilot's"
-	to reveal
-		has "main plot completed"
-	set "revealed map"
 mission "reveal map"
 	invisible
 	landing
@@ -613,3 +593,7 @@ event "reveal map"
 	visit "Zubenelgenubi"
 	visit "Zubenelhakrabi"
 	visit "Zubeneschamali"
+event "all-content"
+	planet "New Boston"
+		add shipyard "all-content"
+		add outfitter "all-content"

--- a/data/starts/hate exploring.txt
+++ b/data/starts/hate exploring.txt
@@ -1,0 +1,20 @@
+start "hate exploring"
+	name "I Hate Exploring"
+	description `You grew up on New Boston, an uninteresting world in the Dirt Belt. You've dreamed of owning a starship ever since your first visit to the spaceport at the age of fifteen. After many long years of working at a textile mill, you've finally saved enough credits to apply for a pilot's license from the Republic.`
+	description `	This start is identical to the default start, however all systems and wormholes are revealed immediately`
+	thumbnail "scene/lobby"
+	date 16 11 3013
+	system "Rutilicus"
+	planet "New Boston"
+	conversation "default intro"
+	account
+		credits 480000
+		score 400
+		mortgage Mortgage
+			principal 480000
+			interest 0.004
+			term 365
+	set "license: Pilot's"
+	to reveal
+		has "main plot completed"
+	set "revealed map"

--- a/data/starts/hate grinding.txt
+++ b/data/starts/hate grinding.txt
@@ -1,0 +1,16 @@
+start "hate grinding"
+	name "I Hate Grinding"
+	description `You grew up on New Boston, an uninteresting world in the Dirt Belt. You've dreamed of owning a starship ever since your first visit to the spaceport at the age of fifteen. After many long years of working at a textile mill, you've finally saved enough credits to apply for a pilot's license from the Republic.`
+	description `	This start is identical to the default start, however all systems and wormholes are revealed immediately. You also get a lot of money.`
+	thumbnail "scene/lobby"
+	date 16 11 3013
+	system "Rutilicus"
+	planet "New Boston"
+	conversation "default intro"
+	account
+		credits 1000000000
+		score 400
+	set "license: Pilot's"
+	to reveal
+		has "main plot completed"
+	set "revealed map"


### PR DESCRIPTION
Like the start that reveals the entire map, this can only be chosen after completing the main plot (FW story).

The start reveals the entire map *and* gives the player 1 billion credits.